### PR TITLE
[Redux] Flux 패턴 학습을 위한 Counter 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-redux": "^9.2.0",
-        "redux": "^5.0.1"
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -2514,6 +2515,15 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-redux": "^9.2.0",
-    "redux": "^5.0.1"
+    "redux": "^5.0.1",
+    "redux-thunk": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { legacy_createStore } from "redux";
 // import { counterReducer } from "./reducer";
 import "./App.css";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 // App.jsx 안에 액션 객체 직접 정의했었으나,
 const increment = {
@@ -33,11 +33,13 @@ export const store = legacy_createStore(counterReducer);
 
 function App() {
   const counter = useSelector((state) => state);
+  const dispatch = useDispatch();
+
   return (
     <>
       <div>Counter: {counter}</div>
-      <button>-</button>
-      <button>+</button>
+      <button onClick={() => dispatch(increment)}>+</button>
+      <button onClick={() => dispatch(decrement)}>-</button>
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,33 +1,33 @@
 import { legacy_createStore } from "redux";
-import { counterReducer } from "./reducer";
+// import { counterReducer } from "./reducer";
 import "./App.css";
 
 // App.jsx 안에 액션 객체 직접 정의했었으나,
-// const increment = {
-//   type: "increment",
-// };
+const increment = {
+  type: "increment",
+};
 
-// const decrement = {
-//   type: "decrement",
-// };
+const decrement = {
+  type: "decrement",
+};
 // → action.js로 분리하고, 상수/함수로 관리
 
 // 액션 type에 따라 상태를 변경하는 함수
-// const counterReducer = (state = 0, action) => {
-//   switch (action.type) {
-//     case "increment":
-//       return state + 1;
-//     case "decrement":
-//       return state - 1;
-//     default:
-//       return state;
-//   }
-// };
+const counterReducer = (state = 0, action) => {
+  switch (action.type) {
+    case "increment":
+      return state + 1;
+    case "decrement":
+      return state - 1;
+    default:
+      return state;
+  }
+};
 // → reducer.js로 분리
 
 // 상태 저장소: legacy_createStore는 구버전 API (학습용으로 사용)
 // 실제 프로젝트에서는 Redux Toolkit의 configureStore 사용 권장
-// const store = legacy_createStore(counterReducer);
+export const store = legacy_createStore(counterReducer);
 // → store.js로 분리
 
 function App() {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,8 @@ import "./App.css";
 
 // 상태 저장소: legacy_createStore는 구버전 API (학습용으로 사용)
 // 실제 프로젝트에서는 Redux Toolkit의 configureStore 사용 권장
-const store = legacy_createStore(counterReducer);
+// const store = legacy_createStore(counterReducer);
+// → store.js로 분리
 
 function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,47 +1,84 @@
-import { legacy_createStore } from "redux";
+import { combineReducers, legacy_createStore } from "redux";
 // import { counterReducer } from "./reducer";
 import "./App.css";
 import { useDispatch, useSelector } from "react-redux";
 
-// App.jsx 안에 액션 객체 직접 정의했었으나,
-const increment = {
-  type: "increment",
+// 액션 객체 (Action): 상태를 변경할 '의도'를 나타내는 객체
+const increment1 = {
+  type: "increment1",
 };
 
-const decrement = {
-  type: "decrement",
+const decrement1 = {
+  type: "decrement1",
 };
+
+const increment2 = {
+  type: "increment2",
+};
+
+const decrement2 = {
+  type: "decrement2",
+};
+// - type 프로퍼티는 필수, 추가 데이터도 작성할 수 있다
+// - 현재는 counter1, counter2 각각에 대해 + / - 정의
 // → action.js로 분리하고, 상수/함수로 관리
 
-// 액션 type에 따라 상태를 변경하는 함수
-const counterReducer = (state = 0, action) => {
+// 리듀서 (Reducer): 이전 state와 action을 받아 새로운 state를 반환하는 함수
+const counter1Reducer = (state = 0, action) => {
   switch (action.type) {
-    case "increment":
+    case "increment1":
       return state + 1;
-    case "decrement":
+    case "decrement1":
       return state - 1;
     default:
       return state;
   }
 };
+
+const counter2Reducer = (state = 0, action) => {
+  switch (action.type) {
+    case "increment2":
+      return state + 1;
+    case "decrement2":
+      return state - 1;
+    default:
+      return state;
+  }
+};
+// - combineReducers로 합쳐서 하나의 store에서 사용 가능
 // → reducer.js로 분리
 
-// 상태 저장소: legacy_createStore는 구버전 API (학습용으로 사용)
-// 실제 프로젝트에서는 Redux Toolkit의 configureStore 사용 권장
-export const store = legacy_createStore(counterReducer);
+// combineReducers: 여러 개의 리듀서를 하나로 합치는 Redux 유틸 함수
+const rootReducer = combineReducers({ counter1Reducer, counter2Reducer });
+
+// store: Redux의 상태 저장소
+export const store = legacy_createStore(rootReducer);
+// - Redux의 중앙 상태 저장소
+// - legacy_createStore는 구버전 API (학습용으로 사용)
+// - 실제 프로젝트에서는 Redux Toolkit의 configureStore 사용 권장
 // → store.js로 분리
 
-function App() {
-  const counter = useSelector((state) => state);
+// App
+export default function App() {
+  // useSelector: store의 state를 구독
+  const counter1 = useSelector((state) => state.counter1Reducer);
+  const counter2 = useSelector((state) => state.counter2Reducer);
+  // useDispatch: 액션을 store에 전달
   const dispatch = useDispatch();
 
   return (
     <>
-      <div>Counter: {counter}</div>
-      <button onClick={() => dispatch(increment)}>+</button>
-      <button onClick={() => dispatch(decrement)}>-</button>
+      <div>
+        <div>Counter: {counter1}</div>
+        <button onClick={() => dispatch(increment1)}>+</button>
+        <button onClick={() => dispatch(decrement1)}>-</button>
+      </div>
+      <div>
+        <div>Counter: {counter2}</div>
+        <button onClick={() => dispatch(increment2)}>+</button>
+        <button onClick={() => dispatch(decrement2)}>-</button>
+      </div>
     </>
   );
 }
-
-export default App;
+// - 각각 counter1, counter2 상태를 구독하고 버튼 클릭 시 액션 dispatch

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,19 @@ import "./App.css";
 // };
 // → action.js로 분리하고, 상수/함수로 관리
 
+// 액션 type에 따라 상태를 변경하는 함수
+const counterReducer = (state = 0, action) => {
+  switch (action.type) {
+    case "increment":
+      return state + 1;
+    case "decrement":
+      return state - 1;
+    default:
+      return state;
+  }
+};
+// → reducer.js로 분리 예정
+
 function App() {
   return (
     <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,13 @@
 import "./App.css";
 
+const increment = {
+  type: "increment",
+};
+
+const decrement = {
+  type: "decrement",
+};
+
 function App() {
   return (
     <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { legacy_createStore } from "redux";
 // import { counterReducer } from "./reducer";
 import "./App.css";
+import { useSelector } from "react-redux";
 
 // App.jsx 안에 액션 객체 직접 정의했었으나,
 const increment = {
@@ -31,9 +32,10 @@ export const store = legacy_createStore(counterReducer);
 // → store.js로 분리
 
 function App() {
+  const counter = useSelector((state) => state);
   return (
     <>
-      <div>Counter: 0</div>
+      <div>Counter: {counter}</div>
       <button>-</button>
       <button>+</button>
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-import { combineReducers, legacy_createStore } from "redux";
+import { applyMiddleware, combineReducers, legacy_createStore } from "redux";
 // import { counterReducer } from "./reducer";
 import "./App.css";
 import { useDispatch, useSelector } from "react-redux";
+import { thunk } from "redux-thunk";
 
 // 액션 객체 (Action): 상태를 변경할 '의도'를 나타내는 객체
 const increment1 = {
@@ -51,12 +52,17 @@ const counter2Reducer = (state = 0, action) => {
 // combineReducers: 여러 개의 리듀서를 하나로 합치는 Redux 유틸 함수
 const rootReducer = combineReducers({ counter1Reducer, counter2Reducer });
 
-// store: Redux의 상태 저장소
-export const store = legacy_createStore(rootReducer);
-// - Redux의 중앙 상태 저장소
-// - legacy_createStore는 구버전 API (학습용으로 사용)
+// store
+export const store = legacy_createStore(rootReducer, applyMiddleware(thunk));
+// - Redux의 중앙 상태 저장소, legacy_createStore는 구버전 API (학습용으로 사용)
 // - 실제 프로젝트에서는 Redux Toolkit의 configureStore 사용 권장
 // → store.js로 분리
+
+// redux-thunk
+// - 원래 dispatch는 객체만 받을 수 있다, thunk 미들웨어를 추가하면 dispatch에 함수도 전달할 수 있다.
+// - dispatch에 함수가 전달되면, 미들웨어가 이 함수를 실행하면서 인자로 dispatch, getState를 넘겨준다.
+// - 따라서 함수 안에서 비동기 로직을 수행한 뒤, 필요할 때 dispatch를 호출해 상태를 변경할 수 있다.
+// - 실무에서는 보통 이 안에서 fetch/axios 같은 API 호출을 수행하고, 성공/실패 결과에 따라 dispatch를 실행한다고 한다.
 
 // App
 export default function App() {
@@ -70,8 +76,29 @@ export default function App() {
     <>
       <div>
         <div>Counter: {counter1}</div>
-        <button onClick={() => dispatch(increment1)}>+</button>
-        <button onClick={() => dispatch(decrement1)}>-</button>
+        {/* 버튼 클릭 시 1초 뒤에 액션을 dispatch */}
+        <button
+          onClick={() =>
+            dispatch((dispatch) => {
+              setTimeout(() => {
+                dispatch(increment1); // 1초 후에 증가 액션 실행
+              }, 1000);
+            })
+          }
+        >
+          +
+        </button>
+        <button
+          onClick={() =>
+            dispatch((dispatch) => {
+              setTimeout(() => {
+                dispatch(decrement1); // 1초 후에 감소 액션 실행
+              }, 1000);
+            })
+          }
+        >
+          -
+        </button>
       </div>
       <div>
         <div>Counter: {counter2}</div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import "./App.css";
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <div>Counter: 0</div>
+      <button>-</button>
+      <button>+</button>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,14 @@
 import "./App.css";
 
-const increment = {
-  type: "increment",
-};
+// App.jsx 안에 액션 객체 직접 정의했었으나,
+// const increment = {
+//   type: "increment",
+// };
 
-const decrement = {
-  type: "decrement",
-};
+// const decrement = {
+//   type: "decrement",
+// };
+// → action.js로 분리하고, 상수/함수로 관리
 
 function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,17 +11,17 @@ import "./App.css";
 // → action.js로 분리하고, 상수/함수로 관리
 
 // 액션 type에 따라 상태를 변경하는 함수
-const counterReducer = (state = 0, action) => {
-  switch (action.type) {
-    case "increment":
-      return state + 1;
-    case "decrement":
-      return state - 1;
-    default:
-      return state;
-  }
-};
-// → reducer.js로 분리 예정
+// const counterReducer = (state = 0, action) => {
+//   switch (action.type) {
+//     case "increment":
+//       return state + 1;
+//     case "decrement":
+//       return state - 1;
+//     default:
+//       return state;
+//   }
+// };
+// → reducer.js로 분리
 
 function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,5 @@
+import { legacy_createStore } from "redux";
+import { counterReducer } from "./reducer";
 import "./App.css";
 
 // App.jsx 안에 액션 객체 직접 정의했었으나,
@@ -22,6 +24,10 @@ import "./App.css";
 //   }
 // };
 // → reducer.js로 분리
+
+// 상태 저장소: legacy_createStore는 구버전 API (학습용으로 사용)
+// 실제 프로젝트에서는 Redux Toolkit의 configureStore 사용 권장
+const store = legacy_createStore(counterReducer);
 
 function App() {
   return (

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,0 +1,9 @@
+// 액션 타입 상수 정의
+export const INCREMENT = "counter/increment";
+export const DECREMENT = "counter/decrement";
+
+// 액션 생성 함수
+export const increment = () => ({ type: INCREMENT });
+export const decrement = () => ({ type: DECREMENT });
+// - 단순 객체 { type: "..." }를 직접 쓰는 대신 함수로 감싸서 재사용/확장 가능
+// - payload, meta 등 추가 데이터도 쉽게 넣을 수 있다

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App, { store } from "./App.jsx";
+import { Provider } from "react-redux";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </StrictMode>
+);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,5 @@
 // 상태와 액션에 따라 새로운 상태를 반환하는 함수
-const counterReducer = (state = 0, action) => {
+export const counterReducer = (state = 0, action) => {
   // 카운터 초기값 0
   switch (
     action.type // action.type에 따라 분기 처리

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,0 +1,16 @@
+// 상태와 액션에 따라 새로운 상태를 반환하는 함수
+const counterReducer = (state = 0, action) => {
+  // 카운터 초기값 0
+  switch (
+    action.type // action.type에 따라 분기 처리
+  ) {
+    case "increment":
+      return state + 1; // 기존 state + 1
+    case "decrement":
+      return state - 1; // 기존 state - 1
+    default: // 일치하는 액션이 없으면 state를 그대로 반환
+      return state;
+  }
+};
+// - 현재는 단일 상태(숫자 카운터)만 관리
+// - 추후 combineReducers 등을 사용해 다른 reducer와 합칠 수 있음

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,4 @@
+import { legacy_createStore } from "redux";
+import { counterReducer } from "./reducer";
+
+export const store = legacy_createStore(counterReducer);


### PR DESCRIPTION
## 🔄 Redux 학습 PR

- Branch: study/redux
- Subject: Flux 패턴 학습을 위한 Redux Counter 구현, 다중 reducer, store 구성 및  redux-thunk 비동기 액션 처리

<br>

## 🧩 Implementation

### Action / Reducer / Store
- 단일 리듀서에서 `다중 리듀서`로 확장 (counter1, counter2)
- `combineReducers`를 통해 rootReducer로 통합
- `legacy_createStore`로 store 생성 (학습 목적, 실제 프로젝트는 RTK configureStore 권장)

### React Redux 연결
- `Provider`로 React 컴포넌트 트리에 `store` 주입
  ```jsx
    <Provider store={store}>
        <App />
      </Provider>
  ```
- `useSelector`로 상태 구독, `useDispatch`로 액션 dispatch

### Redux-thunk 적용
- `applyMiddleware(thunk)`로 비동기 액션 처리 가능하도록 설정
- `setTimeout` 기반 1초 지연 액션 실행 예제 구현

<br>

## 📌 What I Learned

- `Flux 패턴`의 기본 사이클: Action → Reducer → Store → View
- 리듀서 확장: 단일 리듀서를 다중 리듀서로 확장하고 `combineReducers`로 rootReducer 구성하는 방법
- `React Redux` 연결: Provider로 store를 주입하고, useSelector, useDispatch로 상태 관리
- redux-thunk 원리: dispatch에 함수를 전달할 수 있고, 비동기 로직 내에서 `dispatch`, `getState` 사용 가능
- 실무 활용: `thunk` 안에서 `fetch/axios` API 호출 후, 결과를 `dispatch`로 상태에 반영
- 추후 개선: actions, reducers, store 파일 분리 예정

<br>

## 📚 Reference

Docs
- [Redux](https://redux.js.org/)
- [React-Redux](https://react-redux.js.org/) 
- [Writing Logic with Thunks](https://redux.js.org/usage/writing-logic-thunks)

GitHub
- [redux / redux](https://github.com/reduxjs/redux)
- [redux/ redux-toolkit](https://github.com/reduxjs/redux-toolkit)
- [redux / react-redux](https://github.com/reduxjs/react-redux)
- [redux  / redux-thunk](https://github.com/reduxjs/redux-thunk?tab=readme-ov-file)

<br>

--- 

💡 이 브랜치는 Redux 학습용 브랜치입니다.